### PR TITLE
Fix stick casting overflow.

### DIFF
--- a/BetterJoyForCemu/Joycon.cs
+++ b/BetterJoyForCemu/Joycon.cs
@@ -652,14 +652,14 @@ namespace BetterJoyForCemu {
 			}
 
 			if (xin != null) {
-                if (other != null | isPro) {
-                    report.SetAxis(Xbox360Axes.LeftThumbX, (short)Math.Max(Int16.MinValue, Math.Min(Int16.MaxValue, stick[0] * (stick[0] > 0 ? Int16.MaxValue : -Int16.MinValue))));
-                    report.SetAxis(Xbox360Axes.LeftThumbY, (short)Math.Max(Int16.MinValue, Math.Min(Int16.MaxValue, stick[1] * (stick[1] > 0 ? Int16.MaxValue : -Int16.MinValue))));
-                    report.SetAxis(Xbox360Axes.RightThumbX, (short)Math.Max(Int16.MinValue, Math.Min(Int16.MaxValue, stick2[0] * (stick2[0] > 0 ? Int16.MaxValue : -Int16.MinValue))));
-                    report.SetAxis(Xbox360Axes.RightThumbY, (short)Math.Max(Int16.MinValue, Math.Min(Int16.MaxValue, stick2[1] * (stick2[1] > 0 ? Int16.MaxValue : -Int16.MinValue))));
+                if (other != null || isPro) {
+                    report.SetAxis(Xbox360Axes.LeftThumbX, CastStickValue(stick[0]));
+                    report.SetAxis(Xbox360Axes.LeftThumbY, CastStickValue(stick[1]));
+                    report.SetAxis(Xbox360Axes.RightThumbX, CastStickValue(stick2[0]));
+                    report.SetAxis(Xbox360Axes.RightThumbY, CastStickValue(stick2[1]));
                 } else { // single joycon mode
-                    report.SetAxis(Xbox360Axes.LeftThumbY, (short)((isLeft ? 1 : -1) * Math.Max(Int16.MinValue, Math.Min(Int16.MaxValue, stick[0] * (stick[0] > 0 ? Int16.MaxValue : -Int16.MinValue)))));
-                    report.SetAxis(Xbox360Axes.LeftThumbX, (short)((isLeft ? -1 : 1) * Math.Max(Int16.MinValue, Math.Min(Int16.MaxValue, stick[1] * (stick[1] > 0 ? Int16.MaxValue : -Int16.MinValue)))));
+                    report.SetAxis(Xbox360Axes.LeftThumbY, CastStickValue((isLeft ? 1 : -1) * stick[0]));
+                    report.SetAxis(Xbox360Axes.LeftThumbX, CastStickValue((isLeft ? -1 : 1) * stick[1]));
                 }
                 report.SetAxis(Xbox360Axes.LeftTrigger, (short)(buttons[(int)(isLeft ? Button.SHOULDER_2 : Button.SHOULDER2_2)] ? Int16.MaxValue : 0));
 				report.SetAxis(Xbox360Axes.RightTrigger, (short)(buttons[(int)(isLeft ? Button.SHOULDER2_2 : Button.SHOULDER_2)] ? Int16.MaxValue : 0));
@@ -667,6 +667,7 @@ namespace BetterJoyForCemu {
 
 			return 0;
 		}
+
 		private void ExtractIMUValues(byte[] report_buf, int n = 0) {
 			gyr_r[0] = (Int16)(report_buf[19 + n * 12] | ((report_buf[20 + n * 12] << 8) & 0xff00));
 			gyr_r[1] = (Int16)(report_buf[21 + n * 12] | ((report_buf[22 + n * 12] << 8) & 0xff00));
@@ -745,6 +746,11 @@ namespace BetterJoyForCemu {
             s[1] = dy / (dy > 0 ? t[1] : t[5]);
 			return s;
 		}
+
+        private short CastStickValue(float stick_value)
+        {
+            return (short)Math.Max(Int16.MinValue, Math.Min(Int16.MaxValue, stick_value * (stick_value > 0 ? Int16.MaxValue : -Int16.MinValue)));
+        }
 
 		public void SetRumble(float low_freq, float high_freq, float amp, int time = 0) {
 			if (state <= Joycon.state_.ATTACHED) return;


### PR DESCRIPTION
Hey there.

TL;DR;
There was an overflow at some edge case when converting from the float [-1, 1]~ish value to the short [-2^15, 2^15 - 1] value for the sticks. This commit fixes it.

Not TL;DR;
When casting from float to short, most casts were "guarded" by min-max correction before casting, however some weren't guarded properly, causing the cast to yield the wrong value.
Below is a code sample showing why it happened. It mostly has to do with how casting works from higher precision types to lower precision ones.
The specific place the code fails is when in the single joy-con mode the resulting float value is multiplied by -1 before being cased to short. In the case the float value was `Int16.MinValue` (being -32768) it will result in a value of 32768, which is equal to `Int16.MaxValue` (32767) + 1, so this value is out of the range that a short supports.

Here's the code sample.
https://rextester.com/JEUU57427

P.S. 1 - To nitpick a bit, the value should be rounded before casting, as in DoSomething2 in the code sample, to achieve better (meaningless) accuracy. I did not change that logic, feel free to do so yourself if desired.
P.S. 2 - I'm not sure in what IDE the code is edited normally but the indention is really mixed, and VS2017 on my setup does reformat on save. I just kept the old mix formatting to keep the commit clean but I suggest you reformat the code in some commit.

Keep up the good work.