### PR TITLE
Hide window instead of showing as tool window on desktop

### DIFF
--- a/BetterJoyForCemu/MainForm.cs
+++ b/BetterJoyForCemu/MainForm.cs
@@ -51,11 +51,12 @@ namespace BetterJoyForCemu {
             this.WindowState = FormWindowState.Minimized;
             notifyIcon.Visible = true;
             notifyIcon.ShowBalloonTip(1);
-            this.FormBorderStyle = FormBorderStyle.FixedToolWindow;
             this.ShowInTaskbar = false;
+            this.Hide();
         }
 
         private void ShowFromTray() {
+            this.Show();
             this.WindowState = FormWindowState.Normal;
             this.ShowInTaskbar = true;
             this.FormBorderStyle = FormBorderStyle.FixedSingle;


### PR DESCRIPTION
I don't know if it was intended or not, but when minimizing the window stayed as a tool window on the desktop, which is a bit weird in my opinion. With this the window now fully hides when minimizing.