### PR TITLE
Same joycon LEDs when joined

### DIFF
--- a/BetterJoyForCemu/MainForm.cs
+++ b/BetterJoyForCemu/MainForm.cs
@@ -150,6 +150,13 @@ namespace BetterJoyForCemu {
                             v.other = jc;
                             jc.other = v;
 
+                            //Set both Joycon LEDs to the one with the lowest ID
+                            byte led = jc.LED <= v.LED ? jc.LED : v.LED;
+                            jc.LED = led;
+                            v.LED = led;
+                            jc.SetLED(led);
+                            v.SetLED(led);
+
                             v.xin.Dispose();
                             v.xin = null;
 
@@ -182,6 +189,12 @@ namespace BetterJoyForCemu {
                     foreach (Button b in con)
                         if (b.Tag == v.other)
                                 b.BackgroundImage = v.other.isLeft ? Properties.Resources.jc_left_s : Properties.Resources.jc_right_s;
+
+                    //Set original Joycon LEDs
+                    v.other.LED = (byte)(0x1 << v.other.PadId);
+                    v.LED = (byte)(0x1 << v.PadId);
+                    v.other.SetLED(v.other.LED);
+                    v.SetLED(v.LED);
 
                     v.other.other = null;
                     v.other = null;

--- a/BetterJoyForCemu/MainForm.resx
+++ b/BetterJoyForCemu/MainForm.resx
@@ -765,9 +765,6 @@
   <metadata name="btnTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>247, 17</value>
   </metadata>
-  <metadata name="btnTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>247, 17</value>
-  </metadata>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAUAEBAAAAEAIABoBAAAVgAAABgYAAABACAAiAkAAL4EAAAgIAAAAQAgAKgQAABGDgAAMDAAAAEA

--- a/BetterJoyForCemu/Program.cs
+++ b/BetterJoyForCemu/Program.cs
@@ -221,6 +221,13 @@ namespace BetterJoyForCemu {
                             temp.other = v;
                             v.other = temp;
 
+                            //Set both Joycon LEDs to the one with the lowest ID
+                            byte led = temp.LED <= v.LED ? temp.LED : v.LED;
+                            temp.LED = led;
+                            v.LED = led;
+                            temp.SetLED(led);
+                            v.SetLED(led);
+
                             temp.xin.Dispose();
                             temp.xin = null;
 


### PR DESCRIPTION
When using two joycon as one joined controller, now both joycon show the same player LED, like on the Switch.