### PR TITLE
Fix exception when pressing Add Controllers button

### DIFF
--- a/BetterJoyForCemu/3rdPartyControllers.cs
+++ b/BetterJoyForCemu/3rdPartyControllers.cs
@@ -29,8 +29,13 @@ namespace BetterJoyForCemu {
 
         private bool ContainsText(ListBox a, String manu) {
             foreach (var v in a.Items)
-                if ((v as dynamic).Text.Equals(manu))
+            {
+                dynamic d = v as dynamic;
+                if (d.Text == null)
+                    continue;
+                if (d.Text.Equals(manu))
                     return true;
+            }
             return false;
         }
 


### PR DESCRIPTION
More specifically, the exception:
```
Microsoft.CSharp.RuntimeBinder.RuntimeBinderException: Cannot perform runtime binding on a null reference
   at CallSite.Target(Closure , CallSite , Object , String )
   at System.Dynamic.UpdateDelegates.UpdateAndExecute2[T0,T1,TRet](CallSite site, T0 arg0, T1 arg1)
   at BetterJoyForCemu._3rdPartyControllers.ContainsText(ListBox a, String manu)
   at BetterJoyForCemu._3rdPartyControllers.RefreshControllerList()
   at BetterJoyForCemu._3rdPartyControllers..ctor()
   at BetterJoyForCemu.MainForm.btn_open3rdP_Click(Object sender, EventArgs e)
   at System.Windows.Forms.Control.OnClick(EventArgs e)
   at System.Windows.Forms.Button.OnClick(EventArgs e)
   at System.Windows.Forms.Button.OnMouseUp(MouseEventArgs mevent)
   at System.Windows.Forms.Control.WmMouseUp(Message& m, MouseButtons button, Int32 clicks)
   at System.Windows.Forms.Control.WndProc(Message& m)
   at System.Windows.Forms.ButtonBase.WndProc(Message& m)
   at System.Windows.Forms.Button.WndProc(Message& m)
   at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
```

I don't understand why it happens though. Maybe because of empty entries in the window?
![BetterJoyForCemu_2019-05-17_18-26-31](https://user-images.githubusercontent.com/665679/57959522-3fc74500-78d2-11e9-827f-ce1119ea471e.png)

The controller I'm using is [here](https://smile.amazon.com/gp/product/B07GXGK3G7/).

(I also get an error running a dev build of the program [here](https://github.com/Davidobot/BetterJoyForCemu/blob/8c2dcff72342b13bc08e91245b89e4dd9f82ef0a/BetterJoyForCemu/Program.cs#L53) (even after copying the nightly's DLL over, which did work):
```
System.BadImageFormatException: 'An attempt was made to load a program with an incorrect format. (Exception from HRESULT: 0x8007000B)'
```
But I fixed that by building HID API myself and using that copy.)